### PR TITLE
Add DB logging

### DIFF
--- a/vellxr/settings.py
+++ b/vellxr/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'user',
+    'django_db_logger',
     'cloudinary'
 ]
 
@@ -154,6 +155,7 @@ DATABASES['default'].update(prod_db)
 SECURE_SSL_REDIRECT = True
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+'''
 logging.config.dictConfig({
     'version': 1,
     'disable_existing_loggers': False,
@@ -195,6 +197,32 @@ logging.config.dictConfig({
 })
 
 '''
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
+        },
+        'simple': {
+            'format': '%(levelname)s %(asctime)s %(message)s'
+        },
+    },
+    'handlers': {
+        'db_log': {
+            'level': 'DEBUG',
+            'class': 'django_db_logger.db_log_handler.DatabaseLogHandler'
+        },
+    },
+    'loggers': {
+        'db': {
+            'handlers': ['db_log'],
+            'level': 'DEBUG'
+        }
+    }
+}
+
 CKEDITOR_JQUERY_URL = 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js'
 CKEDITOR_BASEPATH = os.path.join(STATIC_ROOT, 'ckeditor/ckeditor/')
 CKEDITOR_CONFIGS = {


### PR DESCRIPTION
Adding 3rd party logging as default `LOGGER` to monitor critical errors directly in admin panel instead through the console.